### PR TITLE
Removing link to outdated supporters page

### DIFF
--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -61,6 +61,4 @@
     Francisco! We hope to serve as a role model and resource for other
     makerspaces and hackerspaces around the world.
 
-  %p We are so grateful to #{link_to "our supporters", supporters_path} for helping us thrive!
-
   = render "donate"


### PR DESCRIPTION
Checked with Tina and she agrees (https://github.com/doubleunion/doubleunion-dot-org/issues/13).

We could also remove the page itself, probably.