### PR TITLE
Updating text on several pages of the site

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -12,6 +12,7 @@
         %li= link_to 'Membership', membership_path
         %li= external_link_to 'Blog', TUMBLR_URL
         %li= link_to 'About', about_path
+        %li= link_to 'Visiting', visit_path
       %ul.nav.navbar-nav.pull-right
         %li{'data-toggle' => 'modal', 'data-target' => '#log_in'}
           = link_to "Log In", "#{DU_APP_URL}/login"

--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -6,6 +6,7 @@
   %li #{link_to "History", "#history"}
   %li #{link_to "Decisionmaking at Double Union", "#decisionmaking"}
   %li #{link_to "Leadership", "#leadership"}
+  %li #{link_to "Tools", "#tools"}
 
 %h3#history History
 
@@ -19,7 +20,7 @@
   Double Union calls itself a hacker / maker space, because our mission is to create a space where women can feel equally comfortable knitting, coding, drawing, or using power tools and no one feels pressure to prove they belong here. We’re creating a culture where we don’t just make awesome stuff - we also ask questions, feel confused sometimes, and break things.
 
 %p
-  Another value we hold at Double Union is the idea that clearly defined structures and boundaries help create safer spaces. We have a shared anti-harassment policy and a list of base assumptions for members. 
+  Another value we hold at Double Union is the idea that clearly defined structures and boundaries help create safer spaces. We have a shared anti-harassment policy and a list of base assumptions for members.
 
 %p
   Double Union’s decision-making structure is heavily influenced by Jo Freeman’s The Tyranny of Structurelessness and has evolved over time as the organization has grown. At first, the people meeting informally made a lot of the founding decisions. After a couple of months, three people volunteered to incorporate Double Union and became the board of directors, responsible for making legal, financial, and high-level decisions. We also created the position of voting member, to decide on new member applications and take on higher-level responsibilities within the organization. A few weeks later, we created committees to make decisions about specific areas like screen printing and electronics. After about a year, we created committees to formalize and document all of our official and de-facto decision-making policies. We also paid multiculturalism and inclusion consultants about 15% of our annual budget to advise us on making Double Union more welcoming to a wider variety of women.
@@ -27,10 +28,10 @@
 %h3#decisionmaking Decisionmaking at Double Union
 
 %p
-  We have a members-only mailing list and internal chat system where we propose and discuss things, and we have members meetings about once a month. This usually results in decisions without a formal process being necessary. Groups of 2+ members interested in a topic form committees, which generally have pre-approved budgets, to run events or be in charge of some aspect of the space's operation.
+  We have a members-only mailing list and internal chat system where we propose and discuss things, and we have members meetings about once a month. This usually results in decisions without a formal process being necessary. Groups of 2+ members interested in a topic form committees, to run events or be in charge of some aspect of the space's operation.
 
 %p
-  Our committees so far include bicycles, electronics, jobs, open source software, zine making, printmaking and textiles, public speaking, 3D printing/CNC machining. We also have several committees related to running Double Union together, such as developing our web application, networking/IT for the space, designing its physical space and constructing modifications, finance/administration, membership coordination, and maintaining the book library.
+  Our committees can be about a topic, such as bicycles or zinemaking. We also have several committees related to running Double Union together, such as developing our web applications, membership coordination, and updating our social media.
 
 %p
   If something is hard to decide, controversial, or otherwise needs a final decision, our small board makes the decision. We don't want to get stuck in endless discussions; having a board avoids that problem. The board also does the legal and financial decision making involved in being a non-profit.
@@ -65,4 +66,46 @@
   =image_tag "mathilde_mouw.jpg"
   %h4 Mathilde Mouw, Board Member
 
-  %p Mathilde is a software engineer and creative technologist. She spends her waking hours, outside of her day job, looking for ways to do art and tech at the same time, such as writing code that makes music. She enjoys dancing ballet and mentoring new programmers who are entering the tech industry. 
+  %p Mathilde is a software engineer and creative technologist. She spends her waking hours, outside of her day job, looking for ways to do art and tech at the same time, such as writing code that makes music. She enjoys dancing ballet and mentoring new programmers who are entering the tech industry.
+
+%h3#tools Tools
+
+%p
+  Below are some of the tools and activities you can find at Double Union!
+
+.tools
+  .tool
+    =image_tag "sewing.jpg"
+    %h4 Sewing and Fiber Arts
+
+  .tool
+    =image_tag "electronics.jpg"
+    %h4 Electronics
+
+  .tool
+    =image_tag "drawing.jpg"
+    %h4 Drawing
+
+  .tool
+    =image_tag "silk_screening.jpg"
+    %h4 Silk Screening Tools
+
+  .tool
+    =image_tag "3d_printer_and_cnc.jpg"
+    %h4 3D Printer and CNC
+
+  .tool
+    =image_tag "hand_tools.jpg"
+    %h4 Hand Tools
+
+  .tool
+    =image_tag "button_maker.jpg"
+    %h4 Button Maker
+
+  .tool
+    =image_tag "library.jpg"
+    %h4 Library
+
+  .tool
+    =image_tag "tea.jpg"
+    %h4 Tea, Coffee, and Mugs

--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -17,7 +17,7 @@
   %h3 Double Union is a space for your projects
   %p
     Things women do in this space include sewing, programming, electronics,
-    woodworking, fiber arts of all kinds, and zine making.
+    screenprinting, fiber arts of all kinds, and zine making.
   %p
     Fast internet, shared tools, a carefully curated library of books and
     zines, and discussion spaces make this a great space for working on your
@@ -36,10 +36,6 @@
     be the invited guest of a member. Please do not visit without the express
     invitation of a member. Please do not invite guests unless you are a
     member. Guests may be any gender or age.
-  %p
-    Open house events are open to the general public. Visitors do not need an
-    invitation from a member to attend an open house, and may be any gender
-    or age.
   %p
     You can find out about upcoming events (and learn more about us) on #{link_to 'our blog', TUMBLR_URL},
     following us on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}, or joining our #{link_to "general interest mailing list", MAILING_LIST_GENERAL}.

--- a/app/views/static_pages/membership.html.haml
+++ b/app/views/static_pages/membership.html.haml
@@ -27,7 +27,7 @@
   People work on many things in the space, including adding lights to bicycles, zine making, electronics, public speaking, finding jobs, contributing to open source software, printmaking and textiles, 3D printing, CNC machining, fiber arts, sewing/serging, and reading in the library. We encourage coworking in the space, as long as it doesn't interfere with events or members using the space for its primary purpose: working on projects in a safe and welcoming environment.
 
 %p
-  We have a very active members-only mailing list where events, workshops, and meetings are thought up and scheduled, as well as a members-only calendar. Any member can propose an event or workshop!
+  We have an active members-only mailing list where events, workshops, and meetings are thought up and scheduled, as well as a members-only calendar. Any member can propose an event or workshop!
 
 %h3 Membership benefits and responsibilities
 

--- a/app/views/static_pages/policies.html.haml
+++ b/app/views/static_pages/policies.html.haml
@@ -4,7 +4,7 @@
   The Double Union (DU) community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
 
 %p
-  This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and wiki, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union board.
+  This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and chat, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union board.
 
 %p
   Some Double Union-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
@@ -51,9 +51,9 @@
   Reports will be handled by Double Union’s board of directors. If the person who is harassing you is on the board, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual board member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
 
 %p
-  We will respond within 3 weeks of your report, and sooner if at all possible. We reserve the right to reject any report we believe to have been made in bad faith. 
+  We will respond within 3 weeks of your report, and sooner if at all possible. We reserve the right to reject any report we believe to have been made in bad faith.
 
-%h3 Jurisdiction 
+%h3 Jurisdiction
 
 %p
   This code of conduct applies to Double Union sponsored spaces, but if you are being harassed by a member of the DU community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Double Union community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The board reserves the right to exclude people from the DU community based on their past behavior, including behavior outside DU spaces and behavior towards people who are not in the DU community.

--- a/app/views/static_pages/visit.html.haml
+++ b/app/views/static_pages/visit.html.haml
@@ -38,19 +38,15 @@
   invitation of a member. Please do not invite guests unless you are a member.
   Guests may be any gender or age.
 
+%p
+  We announce public events on #{link_to 'our blog', TUMBLR_URL}, #{link_to "public mailing list", MAILING_LIST_GENERAL}, and on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}.
+
 %h3 Conduct while in the space
 
 %p
   Double Union has a strict #{link_to "anti-harassment policy", policies_path}
   which all visitors and members are expected to follow at all times. This
   policy is enforced by all Double Union members.
-
-%h3 Open house
-
-%p
-  Open house events are open to the general public. Visitors do not need an
-  invitation from a member to attend an open house, and may be any gender or
-  age. We announce open houses on #{link_to 'our blog', TUMBLR_URL}, #{link_to "public mailing list", MAILING_LIST_GENERAL}, and on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}.
 
 %h3 Accessibility
 
@@ -62,50 +58,3 @@
   Double Union is actively working to create a culture where we create and
   maintain accessible space. We will add more accessibility information as we
   go on, and would love feedback on how to improve.
-
-%h3 Tools
-
-%p
-  Below are some of the tools and activities you can find at Double Union!
-
-.tools
-  .tool
-    =image_tag "sewing.jpg"
-    %h4 Sewing and Fiber Arts
-
-  .tool
-    =image_tag "electronics.jpg"
-    %h4 Electronics
-
-  .tool
-    =image_tag "drawing.jpg"
-    %h4 Drawing
-
-  .tool
-    =image_tag "handibot.jpg"
-    %h4 Handibot
-
-  .tool
-    =image_tag "silk_screening.jpg"
-    %h4 Silk Screening Tools
-
-  .tool
-    =image_tag "3d_printer_and_cnc.jpg"
-    %h4 3D Printer and CNC
-
-  .tool
-    =image_tag "hand_tools.jpg"
-    %h4 Hand Tools
-
-  .tool
-    =image_tag "button_maker.jpg"
-    %h4 Button Maker
-
-  .tool
-    =image_tag "library.jpg"
-    %h4 Library
-
-  .tool
-    =image_tag "tea.jpg"
-    %h4 Tea, Coffee, and Mugs
-


### PR DESCRIPTION
I couldn't get the website set up on my laptop to test this properly (I'll try to troubleshoot it later!), but for now, here are some text edits I made:

* Link "Visiting" in the top nav since it's an important page
* Move "Tools" to About page since that makes more sense than on Visiting
* Remove Handibot from Tools
* Update description of committees
* Remove info about open houses since we don't really do those
* Update references to woodworking and the former wiki

This helps with the issue I filed at https://github.com/doubleunion/doubleunion-dot-org/issues/35 !