### PR TITLE
Update anti-harassment form and mailing list links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,3 +191,9 @@ DEPENDENCIES
   sqlite3
   uglifier (>= 1.3.0)
   webmock
+
+RUBY VERSION
+   ruby 2.1.5p273
+
+BUNDLED WITH
+   1.16.0

--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -38,7 +38,7 @@
     member. Guests may be any gender or age.
   %p
     You can find out about upcoming events (and learn more about us) on #{link_to 'our blog', TUMBLR_URL},
-    following us on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}, or joining our #{link_to "general interest mailing list", MAILING_LIST_GENERAL}.
+    following us on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}, or joining our #{link_to "general interest mailing list", MAILING_LIST_GENERAL}. (Note: By clicking on the mailing list link, you will be redirected to our Google Groups page. Click "Join group" to get emails.)
 
   %h3 Membership
   - if @accepting_applications
@@ -46,7 +46,7 @@
       Double Union is accepting new members! Members join through an application and voting process. If you're interested in being part of Double Union, please apply.
   - else
     %p
-      Members join through an application and voting process. If you're interested in being part of Double Union, please subscribe to #{link_to 'our blog', TUMBLR_URL}, #{external_link_to "Twitter", TWITTER_URL}, or #{link_to "general interest mailing list", MAILING_LIST_GENERAL} to receive an announcement when we reopen membership applications.
+      Members join through an application and voting process. If you're interested in being part of Double Union, please subscribe to #{link_to 'our blog', TUMBLR_URL}, #{external_link_to "Twitter", TWITTER_URL}, or #{link_to "general interest mailing list", MAILING_LIST_GENERAL} to receive an announcement when we reopen membership applications. (Note: By clicking on the mailing list link, you will be redirected to our Google Groups page. Click "Join group" to get emails.)
 
   %p
     Check out our #{ link_to "membership page", membership_path } to learn more.

--- a/app/views/static_pages/membership.html.haml
+++ b/app/views/static_pages/membership.html.haml
@@ -2,7 +2,7 @@
 
 - unless @accepting_applications
   .alert.alert-info
-    We aren't currently accepting applications. Join our #{ link_to "general interest mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/public", class: "alert-link"} to be notified when applications are open again!
+    We aren't currently accepting applications. Join our #{ link_to "general interest mailing list", MAILING_LIST_GENERAL, class: "alert-link"} to be notified when applications are open again!
 
 %p
   New members join through an application and voting process. If you're interested in being part of Double Union but aren't sure whether you're “good enough,” please apply - we don't evaluate applicants on whether they're “cool” or accomplished. Read on to hear about what we're looking for, and don't let #{ link_to "impostor syndrome", "http://geekfeminism.wikia.com/wiki/Impostor_syndrome" } stop you.

--- a/app/views/static_pages/membership.html.haml
+++ b/app/views/static_pages/membership.html.haml
@@ -2,7 +2,7 @@
 
 - unless @accepting_applications
   .alert.alert-info
-    We aren't currently accepting applications. Join our #{ link_to "general interest mailing list", "http://lists.doubleunion.org/listinfo.cgi/doubleunion-doubleunion.org", class: "alert-link"} to be notified when applications are open again!
+    We aren't currently accepting applications. Join our #{ link_to "general interest mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/public", class: "alert-link"} to be notified when applications are open again!
 
 %p
   New members join through an application and voting process. If you're interested in being part of Double Union but aren't sure whether you're “good enough,” please apply - we don't evaluate applicants on whether they're “cool” or accomplished. Read on to hear about what we're looking for, and don't let #{ link_to "impostor syndrome", "http://geekfeminism.wikia.com/wiki/Impostor_syndrome" } stop you.

--- a/app/views/static_pages/membership.html.haml
+++ b/app/views/static_pages/membership.html.haml
@@ -3,6 +3,8 @@
 - unless @accepting_applications
   .alert.alert-info
     We aren't currently accepting applications. Join our #{ link_to "general interest mailing list", MAILING_LIST_GENERAL, class: "alert-link"} to be notified when applications are open again!
+    %p
+      (Note: You will be redirected to our Google Groups page. Click "Join group" to get emails.)
 
 %p
   New members join through an application and voting process. If you're interested in being part of Double Union but aren't sure whether you're “good enough,” please apply - we don't evaluate applicants on whether they're “cool” or accomplished. Read on to hear about what we're looking for, and don't let #{ link_to "impostor syndrome", "http://geekfeminism.wikia.com/wiki/Impostor_syndrome" } stop you.

--- a/app/views/static_pages/policies.html.haml
+++ b/app/views/static_pages/policies.html.haml
@@ -45,7 +45,7 @@
 %h3 Reporting
 
 %p
-  <strong>If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, #{ link_to "please submit a report here", "https://docs.google.com/forms/d/1CXOB23OxGKIjmcaM78PZjo6OtP3fz7QbiCt2dts65no/viewform" }.</strong> You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
+  <strong>If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, #{ link_to "please submit a report here", "https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform" }.</strong> You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
 
 %p
   Reports will be handled by Double Union’s board of directors. If the person who is harassing you is on the board, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual board member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -11,6 +11,6 @@ MEMBERSHIP_EMAIL     = I18n.t('du.membership_email')
 TUMBLR_BASE          = 'doubleunion.tumblr.com'
 TUMBLR_URL           = "http://#{TUMBLR_BASE}"
 
-MAILING_LIST_GENERAL = "http://lists.doubleunion.org/listinfo.cgi/doubleunion-doubleunion.org"
+MAILING_LIST_GENERAL = "https://groups.google.com/a/doubleunion.org/forum/#!forum/public"
 GOOGLE_ANALYTICS_ID  = 'UA-47411942-1'
 S3_BUCKET            = "https://s3-us-west-1.amazonaws.com/doubleunion"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+end


### PR DESCRIPTION
outfoxes https://github.com/doubleunion/doubleunion-dot-org/issues/41

QA:
1) Go to doubleunion.org. The two "general interest mailing list" links should now point to the new google group, along with instructions on how to join the mailing list.
2) Go to /membership. The general interest mailing list notification at the top should point to the new google group, along with instructions on how to join.
3) Go to /policies. The "please submit a report here" link should take you to the correct form directly, instead of a deprecated form with a link to the new one.