### PR TITLE
Change gender criteria in public-facing membership page

### DIFF
--- a/app/views/static_pages/membership.html.haml
+++ b/app/views/static_pages/membership.html.haml
@@ -21,7 +21,7 @@
   Double Union welcomes members with a broad variety of interests, skills, identities, backgrounds, and histories. What we have in common is a #{ link_to "set of values (base assumptions)", base_assumptions_path } and an interest in supporting each other and Double Union. We want to accept more members who share our values and our commitment to building a safer space together.
 
 %p
-  To keep the focus on a great space for women (trans, cis, queer, straight, and not-fitting-into-those-labels/other), all members must identify as women in a way that's significant to them. Members must also be old enough to carry out any responsibilities. Guests of members may be any gender or age. We specifically encourage bringing (supervised) children to the space.
+  To keep the focus on a great space for women and non-binary people (trans, cis, queer, straight, and not-fitting-into-those-labels/other), all members must identify as a woman or non-binary person in a way that is significant to them. Members must also be old enough to carry out any responsibilities. Guests of members may be any gender or age. We specifically encourage bringing (supervised) children to the space.
 
 %h3 How do members use the space?
 
@@ -46,7 +46,7 @@
 %ul
   %li Use the space when a key member is present
   %li Store your projects in the space (within reason)
-  %li Bring guests who identify as women in ways that are significant to them
+  %li Bring guests who identify as a woman or non-binary person in a way that is significant to them
 
 %h4 Key members
 


### PR DESCRIPTION
Change "identify as a woman in a way that's significant to them" to "identify as a woman or non-binary person in a way that is significant to them".

The board voted at our last meeting and we are ready at long last to change the language for DU's gender criteria! 

Closes https://github.com/doubleunion/doubleunion-dot-org/issues/49