### PR TITLE
Remove open house text on homepage

### DIFF
--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -26,7 +26,7 @@
     Double Union is a supportive community for feminist activism. We are intersectional
     feminists, centered on women and non-binary people, and queer and trans-inclusive.
 
-  %h3 Visiting Double Union: Classes, Open Houses and Events
+  %h3 Visiting Double Union: Classes and Events
 
   %p
     Double Union is #{link_to "located in San Francisco's Potrero Hill neighborhood", visit_path}.


### PR DESCRIPTION
We don't really do "open house" events. I removed the rest of the mentions of open houses a year ago (https://github.com/doubleunion/doubleunion-dot-org/pull/37) but missed that bit.