### PR TITLE
Update homepage to say when applications close

### DIFF
--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -1,6 +1,6 @@
 - if @accepting_applications
   %p.text-center
-    Double Union is currently accepting applications for membership! Learn more on the #{ link_to "membership page", membership_path, class: "alert-link" }.
+    Double Union is accepting applications for membership through February 11th! Learn more on the #{ link_to "membership page", membership_path, class: "alert-link" }.
 .jumbotron
   .container
     .jumbotron-content


### PR DESCRIPTION
The homepage and http://doubleunion.org/membership don't say when the membership application period ends, so I added that info!