### PR TITLE
Improved visibility of accessibility info on visit page

### DIFF
--- a/app/views/static_pages/visit.html.haml
+++ b/app/views/static_pages/visit.html.haml
@@ -1,6 +1,14 @@
 %h2 Visiting
 
-%h3 Location
+%h3 Table of contents
+
+%ul
+  %li #{link_to "Location", "#location"}
+  %li #{link_to "Access", "#access"}
+  %li #{link_to "Conduct while in the space", "#conduct"}
+  %li #{link_to "Accessibility", "#accessibility"}
+
+%h3#location Location
 
 %p
   We are located in Lower Potrero Hill at #{link_to "1250 Missouri St. #111", "https://www.google.com/maps/place/1250+Missouri+St,+San+Francisco,+CA+94107/@37.7504873,-122.3978271,17z/data=!3m1!4b1!4m2!3m1!1s0x808f7fae0730e01b:0x8ee0ca3bde3eae0d"}, San Francisco.
@@ -30,7 +38,7 @@
 %p
   That’s the building’s front door. If you’re a guest of a member, or a guest attending a public event, you can use the keypad to press #111 (our unit number) to call the phone inside the space.
 
-%h3 Access
+%h3#access Access
 
 %p
   Other than during events open to the public, Double Union visitors must be
@@ -39,20 +47,20 @@
   Guests may be any gender or age.
 
 %p
-  We announce public events on #{link_to 'our blog', TUMBLR_URL}, #{link_to "public mailing list", MAILING_LIST_GENERAL}, and on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}.
+  We announce public events on #{link_to 'our blog', TUMBLR_URL}, #{link_to "public mailing list", MAILING_LIST_GENERAL}, #{external_link_to "Facebook", FACEBOOK_URL}, #{external_link_to "Instagram", INSTAGRAM_URL}, and on Twitter at #{external_link_to "@#{TWITTER_USERNAME}", TWITTER_URL}.
 
-%h3 Conduct while in the space
+%h3#conduct Conduct while in the space
 
 %p
   Double Union has a strict #{link_to "anti-harassment policy", policies_path}
   which all visitors and members are expected to follow at all times. This
   policy is enforced by all Double Union members.
 
-%h3 Accessibility
+%h3#accessibility Accessibility
 
 %p
-  The building that Double Union is located in is fully ADA compliant. To
-  access the space, take the elevator to the first floor (1).
+  The building that Double Union is located in is fully ADA compliant. There is a large elevator to get to the space, and there is an accessible bathroom inside. To
+  access the space, take the elevator to the first floor (1). The upper (loft) area of the space is accessible by elevator (floor 1M).
 
 %p
   Double Union is actively working to create a culture where we create and


### PR DESCRIPTION
This would fix the issue I filed earlier (https://github.com/doubleunion/doubleunion-dot-org/issues/57), reported by a person on Twitter (https://twitter.com/domlet/status/959197539894374400).

Relevant changes:
* Add table of contents with links to headings (similar to https://github.com/doubleunion/doubleunion-dot-org/blob/master/app/views/static_pages/about.html.haml)
* Add anchor tags to headings
* Add more info to accessibility info

Also:
* Add links to Instagram and Facebook

As usual, I haven't tested this locally, just poked around. :)