### PR TITLE
Add links to GitHub repos from bottom of homepage

### DIFF
--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -62,3 +62,6 @@
     makerspaces and hackerspaces around the world.
 
   = render "donate"
+
+  %p
+    You can also reuse or contribute to our open source #{external_link_to "website code", GITHUB_SITE_URL} and #{external_link_to "internal membership management app code", GITHUB_AROOO_URL}.

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -9,11 +9,14 @@ JOIN_EMAIL           = I18n.t('du.join_email')
 MEMBERSHIP_EMAIL     = I18n.t('du.membership_email')
 
 TUMBLR_BASE          = 'doubleunion.tumblr.com'
-TUMBLR_URL           = "http://#{TUMBLR_BASE}"
+TUMBLR_URL           = "https://#{TUMBLR_BASE}"
 
 INSTAGRAM_URL        = 'https://www.instagram.com/doubleunionsf'
 
 FACEBOOK_URL         = 'https://www.facebook.com/doubleunion'
+
+GITHUB_SITE_URL      = 'https://github.com/doubleunion/doubleunion-dot-org'
+GITHUB_AROOO_URL     = 'https://github.com/doubleunion/arooo'
 
 MAILING_LIST_GENERAL = "https://groups.google.com/a/doubleunion.org/forum/#!forum/public"
 GOOGLE_ANALYTICS_ID  = 'UA-47411942-1'


### PR DESCRIPTION
This fixes the issue I filed at https://github.com/doubleunion/doubleunion-dot-org/issues/55 - the website should link to this repo and https://github.com/doubleunion/arooo so that visitors can contribute bug fixes and issue reports if they want to. :)