### PR TITLE
Updating Code of Conduct to reflect CoC Committee

### DIFF
--- a/app/views/static_pages/policies.html.haml
+++ b/app/views/static_pages/policies.html.haml
@@ -4,7 +4,7 @@
   The Double Union (DU) community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
 
 %p
-  This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and chat, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union board.
+  This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and chat, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union Code of Conduct Committee.
 
 %p
   Some Double Union-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
@@ -33,7 +33,7 @@
   %li Publication of non-harassing private communication
 
 %p
-  The Double Union community prioritizes marginalized people’s safety over privileged people’s comfort. The Double Union board will not act on complaints regarding:
+  The Double Union community prioritizes marginalized people’s safety over privileged people’s comfort. The Double Union Code of Conduct Committee will not act on complaints regarding:
 
 %ul
   %li "Reverse" -isms, including "reverse racism," "reverse sexism," and "cisphobia" (because these things don’t exist)
@@ -45,18 +45,18 @@
 %h3 Reporting
 
 %p
-  <strong>If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, #{ link_to "please submit a report here", "https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform" }.</strong> You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
+  <strong>If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, #{ link_to "please submit a report here", "https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform" }.</strong> You may also submit a report or concern by emailing conduct@doubleunion.org. You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
 
 %p
-  Reports will be handled by Double Union’s board of directors. If the person who is harassing you is on the board, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual board member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
+  Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton, Britta Gustafson, and Kendra Albert. (Last updated July 2018.) If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
 
 %p
-  We will respond within 3 weeks of your report, and sooner if at all possible. We reserve the right to reject any report we believe to have been made in bad faith.
+  If you contact the committee with a concern or report, we collectively commit to acknowledging your report within 24 hours. If you contact an individual member of the committee, we cannot commit that specific individual to a specific response time, but they will make their best effort to respond as quickly as possible. By default, we commit to making a decision about your report within 10 business days. Depending on the situation, we may commit (clearly) to a different timeline for a decision. We reserve the right to reject any report we believe to have been made in bad faith.
 
 %h3 Jurisdiction
 
 %p
-  This code of conduct applies to Double Union sponsored spaces, but if you are being harassed by a member of the DU community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Double Union community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The board reserves the right to exclude people from the DU community based on their past behavior, including behavior outside DU spaces and behavior towards people who are not in the DU community.
+  This code of conduct applies to Double Union sponsored spaces, but if you are being harassed by a member of the DU community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Double Union community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The Code of Conduct Committee reserves the right to exclude people from the DU community based on their past behavior, including behavior outside DU spaces and behavior towards people who are not in the DU community.
 
 %h3 Confidentiality
 


### PR DESCRIPTION
Updating our policy to document:

* Reports are now handled by the CoC Committee, not the board
* The names of the current CoC Committee members
* The email address for the CoC Committee
* The timelines that reporters can expect for handling of their reports

I'm going to email this for review by the other CoC Committee members, so I would like us to wait to merge it until I get their ok. :)