### PR TITLE
Small update to feminism description on homepage

### DIFF
--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -23,7 +23,7 @@
     zines, and discussion spaces make this a great space for working on your
     projects, learning skills, and meeting new friends.
   %p
-    Double Union is a supportive community for feminist activism. We are intersectional
+    Double Union is a supportive community for feminist activism. We strive to be intersectional
     feminists, centered on women and non-binary people, and queer and trans-inclusive.
 
   %h3 Visiting Double Union: Classes and Events


### PR DESCRIPTION
This edit updates our homepage language from "We are intersectional feminists" to "We strive to be intersectional feminists", thanks to a suggestion from Dani in a different document!

This frames feminism as active work that members engage in, instead of as an inherent/permanent aspect of our identities. Our space does not always consistently live up to our intersectional goals, but we work toward these intersectional goals.