### PR TITLE
Update Code of Conduct, add Confidentiality Policy

### DIFF
--- a/pages/policies.md
+++ b/pages/policies.md
@@ -5,34 +5,43 @@ title: Policies
 permalink: /policies/
 ---
 
-## Code of Conduct & Anti-Harassment Policy
+### Table of Contents
 
-The Double Union (DU) community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
+* [Code of Conduct](#code-of-conduct)
+* [Confidentiality Policy](#confidentiality-policy)
 
-This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and chat, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union Code of Conduct Committee.
+## Code of Conduct
+
+*Last updated November 2018.*
+
+The Double Union (DU) community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all Double Union sponsored spaces, including our blog, mailing lists, and chat, as well as any other spaces that Double Union hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Double Union Code of Conduct Committee (CoC Committee).
 
 Some Double Union-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+
+[How to report a problem or concern](#reporting)
 
 ### Definitions
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, ethnicity, or religion
+* Sustained disruption of discussion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate
-* Physical contact and simulated physical contact (eg, textual descriptions like “\*hug\*” or “\*backrub\*”) without consent or after a request to stop
+* Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+* Continued one-on-one communication after requests to cease
+* Deliberate “outing” of any aspect of a person’s identity or history of trauma without their consent, except as necessary to protect other DU members or other vulnerable people from intentional abuse
+* Publication of non-harassing private communication
+* Harassing photography or recording, including logging online activity for harassment purposes
+* Unwelcome sexual attention
+* Physical contact and simulated physical contact (for example, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop
 * Threats of violence
 * Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
 * Deliberate intimidation
 * Stalking or following
-* Harassing photography or recording, including logging online activity for harassment purposes
-* Sustained disruption of discussion
-* Unwelcome sexual attention
-* Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
-* Continued one-on-one communication after requests to cease
-* Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other DU members or other vulnerable people from intentional abuse
-* Publication of non-harassing private communication
 
 The Double Union community prioritizes marginalized people’s safety over privileged people’s comfort. The Double Union Code of Conduct Committee will not act on complaints regarding:
 
@@ -46,13 +55,21 @@ The Double Union community prioritizes marginalized people’s safety over privi
 
 **If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, [please submit a report here](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform).** You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
 
-Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton, Britta Gustafson, and Kendra Albert. (Last updated July 2018.) If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
+Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton, Britta Gustafson, and Kendra Albert. If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
 
 If you contact the committee with a concern or report, we collectively commit to acknowledging your report within 24 hours. If you contact an individual member of the committee, we cannot commit that specific individual to a specific response time, but they will make their best effort to respond as quickly as possible. By default, we commit to making a decision about your report within 10 business days. Depending on the situation, we may commit (clearly) to a different timeline for a decision. We reserve the right to reject any report we believe to have been made in bad faith.
 
-### Jurisdiction
+### Scope
 
 This code of conduct applies to Double Union sponsored spaces, but if you are being harassed by a member of the DU community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Double Union community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The Code of Conduct Committee reserves the right to exclude people from the DU community based on their past behavior, including behavior outside DU spaces and behavior towards people who are not in the DU community.
+
+### Goals
+
+The primary goal of Double Union’s Code of Conduct enforcement is to protect Double Union (and its members and other participants) from harm.
+
+There is other work that we do to support our primary goal—for example, showing folks what acceptable behavior looks like, educating individuals as to why their conduct was harmful, and serving as an instantiation of our feminist values—but our first priority is to protect our community, especially members who have been the target of a Code of Conduct violation.
+
+This model means that there are some things the Code of Conduct Committee doesn’t do. We do not facilitate apologies, provide mediation of disputes, coach harassers on how to be better, or pass messages between harassers and targets. We may choose an action that is not exactly the target’s desired response, based on our scope, goal of protecting the community, and understanding of the situation.
 
 ### Confidentiality
 
@@ -60,6 +77,48 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 ### Consequences
 
+If a participant engages in harassing behavior or other behavior that violates the Code of Conduct, the CoC Committee may take any action we deem appropriate. Enforcement of the Code of Conduct does not by itself violate of the Code of Conduct.
+
+Example actions and consequences may include:
+
+* A notice to the members mailing list
+* A personal email warning a person that their behavior was unacceptable
+* Removal of membership
+* A permanent ban from the space
+* Involving the DU Board if there is a legal risk to DU or legal action necessary
+* Identification of a participant as a harasser to other DU members or the general public
+
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-If a participant engages in harassing behavior, Double Union may take any action they deem appropriate, including expulsion from all Double Union spaces and identification of the participant as a harasser to other DU members or the general public.
+## Confidentiality Policy
+
+*Last updated September 2018.*
+
+Double Union tries to be a place where members feel safe, and so it is important to us to foster a culture of consent and respect for the privacy and comfort of other members and of DU. This may be different than the social norms you are used to outside of Double Union, and it’s part of what is special about the space and our community.
+
+Because of that, here are guidelines about situations where you should ask before sharing information, and information that should always be kept confidential. When in doubt, ask first!
+
+You should ask individual members about before sharing:
+* Content from Double Union members-only mailing lists, Slack chats, and Google Drive documents (unless it’s explicitly public, like information about public events)
+* Discussions within members-only meetings
+* Member contact info
+
+Please also ask permission before taking photos of people, and ask permission before sharing them. Examples:
+* “May I take a photo of you working on your project and post it on the Double Union Twitter and Instagram?”
+* “I would like to take a group photo of our event to post on my Facebook page. It’s totally ok to not be in the photo. Can everyone who is not interested in being in this photo move to the kitchen for a moment so that I don’t accidentally get you in the photo?”
+
+These things must always be kept confidential:
+* Double Union authentication credentials (passwords)
+* Door codes and keys
+* Voting members emails, meetings, and shared documents
+* Prospective member applications
+* Member comments on prospective member applications
+* Board emails, meetings, and shared documents
+* Other content in the Double Union internal web application or other platforms that DU uses (e.g. Stripe, LastPass).
+* Information about membership status or dues
+* Internal materials of the Code of Conduct Committee
+* Situations where confidentiality is explicitly requested
+
+For other meetings and events, if you want the content to be kept confidential, please let everyone know at the beginning of your event or in the event description.
+
+If you feel that DU confidentiality has been broken, please report it to the Code of Conduct Committee using [this form](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform). You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.

--- a/pages/policies.md
+++ b/pages/policies.md
@@ -20,7 +20,7 @@ This code of conduct applies to all Double Union sponsored spaces, including our
 
 Some Double Union-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
 
-[How to report a problem or concern](#reporting)
+[**Report a problem or concern**](#reporting)
 
 ### Definitions
 
@@ -53,7 +53,7 @@ The Double Union community prioritizes marginalized people’s safety over privi
 
 ### Reporting
 
-**If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, [please submit a report here](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform).** You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report harassment anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
+**If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, [please submit a report here](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform).** You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report harassment anonymously, or you can choose to include your contact information if you would like the Code of Conduct Committee to follow up with you for further investigation or to communicate actions that have been taken.
 
 Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton, Britta Gustafson, and Kendra Albert. If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
 
@@ -96,7 +96,7 @@ Participants asked to stop any harassing behavior are expected to comply immedia
 
 Double Union tries to be a place where members feel safe, and so it is important to us to foster a culture of consent and respect for the privacy and comfort of other members and of DU. This may be different than the social norms you are used to outside of Double Union, and it’s part of what is special about the space and our community.
 
-Because of that, here are guidelines about situations where you should ask before sharing information, and information that should always be kept confidential. When in doubt, ask first!
+Because of that, here are guidelines for members about situations where you should ask before sharing information, and information that should always be kept confidential. When in doubt, ask first!
 
 You should ask individual members about before sharing:
 * Content from Double Union members-only mailing lists, Slack chats, and Google Drive documents (unless it’s explicitly public, like information about public events)
@@ -121,4 +121,4 @@ These things must always be kept confidential:
 
 For other meetings and events, if you want the content to be kept confidential, please let everyone know at the beginning of your event or in the event description.
 
-If you feel that DU confidentiality has been broken, please report it to the Code of Conduct Committee using [this form](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform). You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report anonymously, or you can choose to include your contact information if you would like Double Union to follow up with you for further investigation or to communicate actions that have been taken.
+If you feel that DU confidentiality has been broken, please report it to the Code of Conduct Committee using [this form](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform). You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report anonymously, or you can choose to include your contact information if you would like the Code of Conduct Committee to follow up with you for further investigation or to communicate actions that have been taken.


### PR DESCRIPTION
On behalf of the Code of Conduct committee, here are revisions to the Code of Conduct and publication of the Confidentiality Policy (which is an existing policy, just now made public as part of our website).

For members, see [the internal document here](https://docs.google.com/document/d/1ZDqY7SaOuwt3toSLgB8JecOsnyxJ7tkX7Rakse8wne0/edit) with details about this revision, which we shared with the DU members list for review and suggestions (which we incorporated). Changes to the CoC include:

* We renamed it as the “Code of Conduct” (instead of the “Code of Conduct & Anti-Harassment Policy”)
* Update “Consequences” section to list example consequences (emails, removal of membership) and add that we may involve DU Board if significant legal risk to DU
* Rename “Jurisdiction” section to “Scope” to reduce legalistic language
* Reordered list of types of harassment to group related topics together (no changes to actual content)
* Added ethnicity to the list of things upon which offensive comments are prohibited
* Add a “Goals” section that explains our thought model and what we don’t do (such as mediation)
* Add a shortcut reporting link to the top of the page
* Standardized language as “target” (instead of “victim”)
* Clarified that CoC Committee will respond to reports/make decisions, not “DU” as a whole

We also incorporated the DU [Confidentiality Policy](https://docs.google.com/document/d/1X7UEBNjojwB90Wuewfk4IiDpV2oL6av9mqdD8F0zXzY/edit) into this page as a closely related policy (the CoC Committee handles reports of issues for both the CoC itself and for the Confidentiality Policy).