### PR TITLE
Update Code of Conduct Committee membership

### DIFF
--- a/pages/policies.md
+++ b/pages/policies.md
@@ -12,7 +12,7 @@ permalink: /policies/
 
 ## Code of Conduct
 
-*Last updated November 2018.*
+*Last updated January 2019.*
 
 The Double Union (DU) community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion. We do not tolerate harassment of participants in any form.
 
@@ -55,7 +55,7 @@ The Double Union community prioritizes marginalized people’s safety over privi
 
 **If you are being harassed by a member of the Double Union community, notice that someone else is being harassed, or have any other concerns, [please submit a report here](https://docs.google.com/forms/d/e/1FAIpQLScijkJU_G43u-GJ69-PJEpuWgrUMZEpgVHXj0fkw_YCkU9n4A/viewform).** You may also submit a report or concern by emailing [{{ site.emails.conduct }}](mailto:{{ site.emails.conduct }}). You may report harassment anonymously, or you can choose to include your contact information if you would like the Code of Conduct Committee to follow up with you for further investigation or to communicate actions that have been taken.
 
-Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton, Britta Gustafson, and Kendra Albert. If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
+Reports will be handled by the Double Union Code of Conduct Committee, which is currently Amy Bickerton and Britta Gustafson. If the person who is harassing you is on the CoC Committee, they will recuse themselves from handling your incident. In this situation, you may also reach out to an individual CoC Committee member instead of submitting a report on the form, or have a friend submit your report. Otherwise, please do not reach out to private email addresses or social media accounts for reporting harassment.
 
 If you contact the committee with a concern or report, we collectively commit to acknowledging your report within 24 hours. If you contact an individual member of the committee, we cannot commit that specific individual to a specific response time, but they will make their best effort to respond as quickly as possible. By default, we commit to making a decision about your report within 10 business days. Depending on the situation, we may commit (clearly) to a different timeline for a decision. We reserve the right to reject any report we believe to have been made in bad faith.
 


### PR DESCRIPTION
Removing Kendra from our list of committee members because their term has wrapped up! We're planning to add new members shortly but have not yet finalized that. We'll update this page again when ready.