### PR TITLE
Updating homepage to balance gender-centering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 
 # Site settings
 title: Double Union
-description: A hacker/maker space for women and non-binary people in San Francisco.
+description: A hacker/maker space for women and nonbinary people in San Francisco.
 
 # Uncomment the below line when applications are open
 # TODO: write some js to fetch from https://app.doubleunion.org/configurations,

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -19,8 +19,7 @@
           Double Union is a hacker/maker space for women and nonbinary people in San Francisco.
         </h2>
         <p>
-          Our goal is to be a community workshop where women and nonbinary people can work on
-          projects in a comfortable, welcoming environment.
+          We are a community workshop for working on projects in a comfortable, welcoming environment.
         </p>
         <div class='home-banner-buttons'>
           <a class='btn btn-primary btn-lg' href='{{ 'membership' | absolute_url }}'>

--- a/index.md
+++ b/index.md
@@ -4,11 +4,11 @@ layout: home
 
 ### Double Union is a space for your projects
 
-Things women and nonbinary people do in this space include sewing, programming, electronics, screenprinting, fiber arts of all kinds, and zine making.
+Things people do in this space include sewing, programming, electronics, screenprinting, fiber arts of all kinds, and zine making.
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists, centered on women and nonbinary people, and queer and trans-inclusive.
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists, centered on nonbinary people and women, and queer and trans-inclusive.
 
 ### Visiting Double Union: Classes and Events
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center women and nonbinary people who are trans, cis, queer, straight, and not-fitting-into-those-labels.
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels.
 
 ### Visiting Double Union: Classes and Events
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists, centered on nonbinary people and women, and queer and trans-inclusive.
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center women and nonbinary people who are trans, cis, queer, straight, and not-fitting-into-those-labels.
 
 ### Visiting Double Union: Classes and Events
 


### PR DESCRIPTION
This change is a draft that comes out of CoCC [notes and discussions in this document](https://docs.google.com/document/d/1Go3bDUJ0dLTSQ2FCv3GQkXiluzcPtA9R0PHjkUhxNN8/edit#bookmark=id.a5g046pennfx). It removes some of the repetition of the phrase "women and nonbinary people" on the homepage (because the point is clear from the headline), and it flips one of the phrases to be "nonbinary people and women".

We plan to review and discuss this draft at our next CoCC meeting, but all members please feel free to comment in that doc if you have suggestions or questions!