### PR TITLE
Clarify gender language on front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels.
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see membership qualifications.
 
 ### Visiting Double Union: Classes and Events
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see membership qualifications.
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see [membership qualifications]({{ 'membership/#membership-qualifications' | absolute_url }}).
 
 ### Visiting Double Union: Classes and Events
 


### PR DESCRIPTION
Following some Twitter discussion about how "women and nonbinary people" is often used to mean "women and women-lite," we (the CoC Committee) want to make it clear that Double Union's inclusion of nonbinary people includes _all_ nonbinary people, not just those with feminine presentation. This language already exists on our membership qualifications page, but we felt it appropriate to highlight it on the front page, as well. 