### PR TITLE
Basic updates to base assumptions to make orientation easier

### DIFF
--- a/pages/base_assumptions.md
+++ b/pages/base_assumptions.md
@@ -10,12 +10,14 @@ permalink: /base_assumptions/
 We try to make the culture at Double Union more welcoming than the world at large. Here are some of the values and best practices you can expect other members to share, what isn't okay in the space no matter whether you are a member or not, and general guidelines. See also our [code of conduct]({{ 'policies' | absolute_url }}).
 
 ### Values you can assume other members strive to uphold:
-* “Women” includes trans women, not all women have uteri/XX chromosomes/etc.
+* “Women” includes trans women; not all women have uteri/XX chromosomes/etc.
+* Nonbinary people are nonbinary people, not "women-lite", and not men or women with other pronouns
 * LGBTQIA-supportive (lesbian, gay, bisexual, trans, queer, intersex, asexual)
 * The majority of gender-associated differences are socialized, not biological
 * Feminism is good
 * [Meritocracy is a joke](http://www.garann.com/dev/2012/you-keep-using-that-word/)
 * [Intersectionality](http://geekfeminism.wikia.com/wiki/Intersectionality) is super important (credit: Kimberlé Crenshaw)
+* Racism is not okay
 * Classism is not okay
 * Prioritizing women and nonbinary people and our needs is perfectly awesome and needs no excuse
 * If you get called out on something, apologize and learn from it
@@ -26,16 +28,15 @@ We try to make the culture at Double Union more welcoming than the world at larg
 * Taking “reverse sexism” or “reverse racism” seriously
 * Questioning the existence of privilege (white privilege, class privilege, etc)
 * Using the phrase “politically correct” when you are not 100% obviously ironic
-* Requests for feminism 101 education
+* Requests for feminism 101 education (outside of educational events or other times where people invite each other to ask questions)
 * Playing devil’s advocate
-* Asking someone to educate you about an aspect of their identity
-* Telling people how to do feminism right
-* Making statements that assume that everyone shares an experience of privilege (eg. has gone to college, can afford to eat out, can find employment easily, has a functional family)
+* Asking someone to educate you about an aspect of their identity (unless the person has encouraged asking questions)
+* Making statements that assume that everyone shares an experience of privilege (examples: has gone to college, can afford to eat out, can find employment easily, has a functional family)
 * Touching people without explicit verbal consent
 * Policing people’s bodies or what they choose to eat
 * [Taking away someone's keyboard](http://tldp.org/HOWTO/Encourage-Women-Linux-HOWTO/x168.html) instead of showing them how to do it
 * Making fun of people for asking questions showing they lack technical knowledge
 * Petting or interacting with anyone's on-duty service animal
-* Making fun of people with penises, testicles, or XY chromosomes - some women have these
+* Making fun of any kind of body part, shape, or size
 
 [CC BY-SA Double Union](https://creativecommons.org/licenses/by-sa/4.0/)


### PR DESCRIPTION
At the several new member orientations I've facilitated, I've had to make verbal edits to the base assumptions to make them make more sense and answer questions from new members. This is a lightweight edit that addresses these common issues and confusions, including:

* Include specific statement about nonbinary people being valid
* Make sure anti-racism is part of the values statement
* Clarify that it's ok to ask basic feminism questions in situations where that's invited
* Clarify that it's ok to ask questions about a person's identity in situations where that's invited
* Replace Latin abbreviation ("eg") with plain language ("for example")
* No body parts are ok to make fun of, no matter who they belong to

Because this is an essential guiding document for DU, this needs review by members, the CoC committee, and the board.

The base assumptions still need a much more fundamental updating - this is just meant as a patch to tide us over until we figure out what to do with that.