### PR TITLE
Update website to reflect move into storage + more

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,22 +8,28 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see [membership qualifications]({{ 'membership/#membership-qualifications' | absolute_url }}).
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, intersex, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see [membership qualifications]({{ 'membership/#membership-qualifications' | absolute_url }}).
 
 ### Visiting Double Union: Classes and Events
 
-Double Union is [located in San Francisco's Potrero Hill neighborhood]({{ 'visit' | absolute_url }}).
+Double Union is [currently virtual]({{ 'visit' | absolute_url }}). We plan to reopen a physical space when it is safe to gather again, hopefully in 2021.
 
 Other than during events open to the public, Double Union visitors must be the invited guest of a member. Please do not visit without the express invitation of a member. Please do not invite guests unless you are a member. Guests may be any gender or age.
 
-You can find out about upcoming events (and learn more about us) on [our blog]({{ site.urls.tumblr }}), following us on Twitter at [{{ site.twitter_username }}]({{ site.urls.twitter }}), [Facebook]({{ site.urls.facebook }}), [Instagram]({{ site.urls.instagram }}), or joining our [general interest mailing list]({{ site.urls.mailing_list }}). (Note: By clicking on the mailing list link, you will be redirected to our Google Groups page. Click "Join group" or "Subscribe to this group" to get emails.)
+You can find out about upcoming events (and learn more about us) by following our: 
+
+* [Blog]({{ site.urls.tumblr }})
+* [Twitter]({{ site.urls.twitter }})
+* [Facebook]({{ site.urls.facebook }})
+* [Instagram]({{ site.urls.instagram }})
+* Or join our [announcements-only mailing list]({{ site.urls.mailing_list }}), which emails you a link to each new blog post. (This is a Google Groups page. Click "Join group" or "Subscribe to this group" to get emails.)
 
 ### Membership
 
 {% if site.accepting_applications %}
 Double Union is accepting new members! Members join through an application and voting process. If you're interested in being part of Double Union, please apply.
 {% else %}
-Members join through an application and voting process. If you're interested in being part of Double Union, please subscribe to [our blog]({{ site.urls.tumblr }}), [Twitter]({{ site.urls.twitter }}), or [general interest mailing list]({{ site.urls.mailing_list }}) to receive an announcement when we reopen membership applications. (Note: By clicking on the mailing list link, you will be redirected to our Google Groups page. Click "Join group" or "Subscribe to this group" to get emails.)
+Members join through an application and voting process. If you're interested in being part of Double Union, please subscribe to our social media (listed above) to receive an announcement when we reopen membership applications.
 {% endif %}
 
 Check out our [membership page]({{ 'membership' | absolute_url }}) to learn more.

--- a/pages/about.md
+++ b/pages/about.md
@@ -46,7 +46,7 @@ Double Unionâ€™s decision-making structure is heavily influenced by Jo Freemanâ€
 
 At first, the people meeting informally made a lot of the founding decisions. After a couple of months, three people volunteered to incorporate Double Union and became the board of directors, responsible for making legal, financial, and high-level decisions.
 
-Each board member is limited to a two-year term, so our board membership has cycled many times since our founding in 2013. This reduces burnout, ensures that this type of power rotates among members, and encourages a wide range of perspectives on the board over time.
+Each board member has a two-year term (with an optional third year), so our board membership has cycled many times. This reduces burnout, ensures that this type of power rotates among members, and encourages a wide range of perspectives on the board over time.
 
 #### Committees
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -8,32 +8,63 @@ permalink: /about/
 ### Table of contents
 
 * [History](#history)
-* [Decisionmaking at Double Union](#decisionmaking-at-double-union)
+* [Decision-making](#decision-making)
 * [Leadership](#leadership)
 * [Tools](#tools)
 
 ### History
 
-The spark that started Double Union was AdaCamp San Francisco, a feminist unconference in June 2013. At that event, a group of women came together to talk about starting feminist makerspaces where women’s needs are prioritized. Among them was Leigh Honeywell, who had just co-founded Seattle Attic, a feminist makerspace in Seattle, who freely shared her experience and tips for starting a new makerspace. Several women, including Double Union co-founders Amelia Greenhall, Valerie Aurora, and Liz Henry, were inspired to start a similar space in San Francisco. Their inspiration: “What if we had a space that felt like AdaCamp all year round?” They decided to create a space with the primary goal of being a comfortable and welcoming place for women to work on their projects.
-
-After AdaCamp, about 10 women started meeting weekly at each other’s homes to brainstorm. Throughout the summer, they created and documented their shared values, raised money amongst themselves and people they knew, incorporated as a 501(c)(3) non-profit, adopted bylaws (largely based on those of The Ada Initiative), selected a board, got a bank account, and set up various kinds of online infrastructure. In October 2013 the board signed a lease on a space in the Fog Building, at 333 Valencia St in the Mission. After ripping out the carpets, building shelves and workbenches, and taking out the ceiling tiles to reveal hidden skylights, Double Union began accepting new members. In October 2015, Double Union moved to a new space in Potrero Hill at 1250 Missouri St. #111.
-
-Double Union began with the membership gender criteria of people who “identify as a woman in a way significant to them”. In January 2018, members decided to expand this criteria to “identify as a woman or nonbinary person in a way significant to them”. In April 2019, we simplified this phrasing to “all women and nonbinary people” and expanded the description of this on [the membership page]({{ 'membership' | absolute_url }}).
+#### Goals
 
 Double Union calls itself a hacker / maker space, because our goal is to create a space where women and nonbinary people can feel equally comfortable knitting, coding, drawing, or using power tools and no one feels pressure to prove they belong here. Double Union members are creating a culture where we don’t just make awesome stuff - we also ask questions, feel confused sometimes, and break things.
 
 Another value members hold at Double Union is the idea that clearly defined structures and boundaries help create safer spaces. We have a shared  [code of conduct]({{ 'policies' | absolute_url }}) and a list of [base assumptions]({{ 'base_assumptions' | absolute_url }}) for members.
 
-Double Union’s decision-making structure is heavily influenced by Jo Freeman’s The Tyranny of Structurelessness and has evolved over time as the organization has grown. At first, the people meeting informally made a lot of the founding decisions. After a couple of months, three people volunteered to incorporate Double Union and became the board of directors, responsible for making legal, financial, and high-level decisions. They also created the position of voting member, to decide on new member applications and take on higher-level responsibilities within the organization. A few weeks later, they created committees to make decisions about specific areas like screen printing and electronics. After about a year, Double Union members created committees to formalize and document all of our official and de-facto decision-making policies. We also paid multiculturalism and inclusion consultants about 15% of our annual budget to advise us on making Double Union more welcoming to a wider variety of women and nonbinary people.
+#### Founding
 
+The spark that started Double Union was AdaCamp San Francisco, a feminist unconference in June 2013. At that event, a group of women came together to talk about starting feminist makerspaces where women’s needs are prioritized. Among them was Leigh Honeywell, who had just co-founded Seattle Attic, a feminist makerspace in Seattle, who freely shared her experience and tips for starting a new makerspace. Several women, including Double Union co-founders Amelia Greenhall, Valerie Aurora, and Liz Henry, were inspired to start a similar space in San Francisco. Their inspiration: “What if we had a space that felt like AdaCamp all year round?” They decided to create a space with the primary goal of being a comfortable and welcoming place for women to work on their projects.
 
-### Decisionmaking at Double Union
+After AdaCamp, about 10 women started meeting weekly at each other’s homes to brainstorm. Throughout the summer, they created and documented their shared values, raised money amongst themselves and people they knew, incorporated as a 501(c)(3) non-profit, adopted bylaws (largely based on those of The Ada Initiative), selected a board, got a bank account, and set up various kinds of online infrastructure.
 
-We have a members-only mailing list and internal chat system where we propose and discuss things, and we have members meetings about once a month. This usually results in decisions without a formal process being necessary. Groups of 2+ members interested in a topic form committees, to run events or be in charge of some aspect of the space's operation.
+#### Physical spaces
 
-Our committees can be about a topic, such as bicycles or zinemaking. We also have several committees related to running Double Union together, such as developing our web applications, membership coordination, and updating our social media.
+In October 2013, the board signed a lease on a space in the Fog Building, at 333 Valencia St in the Mission. After ripping out the carpets, building shelves and workbenches, and taking out the ceiling tiles to reveal hidden skylights, Double Union began accepting new members.
+
+In October 2015, Double Union moved to a new space in Potrero Hill at 1250 Missouri St. #111. In March 2020, we stopped in-person use of our space except for one-person-at-a-time production of protective equipment for the pandemic, such as fabric masks and face shield structures. In September 2020, we ended our lease and moved our equipment into storage.
+
+When it is safe to gather again, we plan to rent a new space. We intend to reopen in San Francisco or Oakland near a BART station, maintaining our commitment to ADA-compliant (or better) accessibility and a warm and welcoming environment.
+
+#### Growth in membership gender criteria
+
+Double Union began in 2013 with the membership gender criteria of people who “identify as a woman in a way significant to them”. In January 2018, members decided to expand this criteria to “identify as a woman or nonbinary person in a way significant to them”. In April 2019, we simplified this phrasing to “all women and nonbinary people” and expanded the description of this on [the membership page]({{ 'membership' | absolute_url }}).
+
+### Decision-making
+
+Double Union’s decision-making structure is heavily influenced by Jo Freeman’s essay ["The Tyranny of Structurelessness"](https://www.jofreeman.com/joreen/tyranny.htm), and it has evolved over time as the organization has grown.
+
+#### Board members
+
+At first, the people meeting informally made a lot of the founding decisions. After a couple of months, three people volunteered to incorporate Double Union and became the board of directors, responsible for making legal, financial, and high-level decisions.
+
+Each board member is limited to a two-year term, so our board membership has cycled many times since our founding in 2013. This reduces burnout, ensures that this type of power rotates among members, and encourages a wide range of perspectives on the board over time.
+
+#### Committees
+
+Groups of 2+ members interested in a topic form committees, to run events or be in charge of some aspect of the space's operation.
+
+Our committees can be about a topic, such as bicycles, zine-making, or electronics. They can make decisions about that specific area of the space, such as buying or maintaining equipment and teaching workshops.
+
+We also have several committees related to running Double Union together, such as the Code of Conduct committee, developing our web applications, membership coordination, and updating our social media. These kinds of committees formalize, document, and maintain our official and de-facto decision-making policies.
+
+#### Communication
+
+We have a members-only mailing list and internal chat system where we propose and discuss ideas, and we have members meetings about once a month. This usually results in decisions without a formal process being necessary. 
 
 If something is hard to decide, controversial, or otherwise needs a final decision, our small board makes the decision. We don't want to get stuck in endless discussions; having a board avoids that problem. The board also does the legal and financial decision making involved in being a non-profit.
+
+#### Voting members
+
+Members can volunteer to be voting members, who read and decide on new member applications. They receive training and guidance about voting, to encourage fair and inclusive decision-making that upholds our values.
 
 ### Leadership
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -68,6 +68,10 @@ Members can volunteer to be voting members, who read and decide on new member ap
 
 ### Leadership
 
+#### Board
+
+*Contact: board@doubleunion.org*
+
 <div class='leader'>
   <img
     src='{{ "/assets/images/board/nora-trapp.jpg" | relative_url }}'
@@ -123,6 +127,12 @@ Members can volunteer to be voting members, who read and decide on new member ap
     </div>
   </div>
 </div>
+
+#### Membership Coordinator
+
+*Contact: join@doubleunion.org (for prospective members) or membership@doubleunion.org (for current members)*
+
+* **Ana Ulin**
 
 ### Tools
 

--- a/pages/visit.md
+++ b/pages/visit.md
@@ -14,26 +14,11 @@ permalink: /visit/
 
 ### Location
 
-We are located in Lower Potrero Hill at [1250 Missouri St. #111](https://www.google.com/maps/place/1250+Missouri+St,+San+Francisco,+CA+94107/@37.7504873,-122.3978271,17z/data=!3m1!4b1!4m2!3m1!1s0x808f7fae0730e01b:0x8ee0ca3bde3eae0d), San Francisco.
+We are currently virtual-only! 
 
-**Parking a car:**
-there's some parking (one-hour until 6 pm, except on Sunday) on the street in front of the space, but this may be full. There is also street parking along Connecticut Street.
+When it is safe to gather again, we plan to rent a new space. We intend to reopen in San Francisco or Oakland near a BART station, maintaining our commitment to ADA-compliant (or better) accessibility and a warm and welcoming environment. Our equipment is in storage, and we look forward to unpacking and organizing it again.
 
-**Bike parking:**
-feel free to bring your bike up the elevator and inside the space.
-
-**Public transit:**
-the 19 bus stops around the corner, and the 48 bus stops nearby. If you're coming from the East Bay, one way is to get off at Civic Center BART and take the 19 south.
-
-Here’s what our building looks like! When you turn from Cesar Chavez St. onto Missouri St., it’s the tall grey box with large windows:
-
-![Building from street]({{ "/assets/images/building-from-street.jpg" | relative_url }})
-
-The left side of the building has a little tree in front of the main entrance, usually behind a few cars:
-
-![Building closer]({{ "/assets/images/building-closer.jpg" | relative_url }})
-
-That’s the building’s front door. If you’re a guest of a member, or a guest attending a public event, you can use the keypad to press #111 (our unit number) to call the phone inside the space.
+For now, we continue to gather online, with chat and videocall communication, events, and workshops.
 
 ### Access
 
@@ -47,6 +32,6 @@ Double Union has a strict [code of conduct]({{ 'policies' | absolute_url }}) whi
 
 ### Accessibility
 
-The building that Double Union is located in is fully ADA compliant. There is a large elevator to get to the space, and there is an accessible bathroom inside. To access the space, take the elevator to the first floor (1). The upper (loft) area of the space is accessible by elevator (floor 1M).
+When Double Union reopens again, we plan to remain fully ADA compliant. We'll add access information when we get there, such as elevator details!
 
-Double Union is actively working to create a culture where we create and maintain accessible space. We will add more accessibility information as we go on, and would love feedback on how to improve.
+Double Union actively works to create a culture where we create and maintain accessible space.


### PR DESCRIPTION
This has lots of content changes! The main changes are to update the info about our physical space (we don't have one anymore) and reorganize the history page to make more sense. It also has minor edits like including the board email address (people tend to just email join@DU because that's the only email they can find, but it would probably be good for people to be able to find the board address if they need to).

This would also close https://github.com/doubleunion/doubleunion-dot-org/issues/100 (it lists the membership coordinator on the leadership page; the CoC committee is already listed on the policies page).

The history page is way too long - the whole site needs some restructuring - but that would be a later update.