### PR TITLE
Improve info for people who want to donate money

### DIFF
--- a/_includes/donate.html
+++ b/_includes/donate.html
@@ -9,3 +9,11 @@
     Donate via PayPal
   </button>
 </form>
+
+<p>If you'd like to write a check (for example, if you want to donate from your donor-advised fund), you can make it out to Double Union and send it to our mailing address (which is different from our physical address):</p>
+
+<p>
+  Double Union<br/>
+  2443 Fillmore St #380-8811<br/>
+  San Francisco, CA 94115
+</p>

--- a/pages/about.md
+++ b/pages/about.md
@@ -19,7 +19,7 @@ Double Union calls itself a hacker / maker space, because our goal is to create 
 
 Another value members hold at Double Union is the idea that clearly defined structures and boundaries help create better spaces. We have a shared  [code of conduct]({{ 'policies' | absolute_url }}) and a list of [base assumptions]({{ 'base_assumptions' | absolute_url }}) for members.
 
-Double Union is a volunteer-run 501(c)(3) nonprofit. Our EIN is 46-3264631, and you can view our [public IRS filings](https://projects.propublica.org/nonprofits/organizations/463264631).
+Double Union is a volunteer-run 501(c)(3) nonprofit. Our EIN is 46-3264631, and you can view our public IRS filings by looking up Double Union in the [California Registry of Charitable Trusts](https://rct.doj.ca.gov/Verification/Web/Search.aspx?facility=Y).
 
 ### History
 

--- a/pages/support.md
+++ b/pages/support.md
@@ -7,6 +7,8 @@ permalink: /support/
 
 Double Union is supported entirely by donations, membership dues, and volunteers. We would love your support for our makerspace in San Francisco! We hope to serve as a role model and resource for other makerspaces and hackerspaces around the world.
 
+We are a 501(c)(3) nonprofit. Our EIN is 46-3264631, and you can view our public IRS filings by looking up Double Union in the [California Registry of Charitable Trusts](https://rct.doj.ca.gov/Verification/Web/Search.aspx?facility=Y).
+
 ### Make a donation
 
 {% include donate.html %}


### PR DESCRIPTION
Donor-advised funds are increasingly common, and providing instructions can help us get that kind of donation.

I also updated the info for how to view our IRS filings, because the ProPublica site tends to be out of date. The official CA website has the most complete and most recent information.