### PR TITLE
Adjust homepage to try to better appeal to new members

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,17 +9,17 @@
 
     {%- if site.accepting_applications -%}
       <p class='home-applications-open'>
-        Double Union is accepting applications for membership through {{ site.application_deadline }}! Learn more on the <a href="{{ 'membership' | absolute_url }}">membership page</a>.
+        Double Union is accepting applications for membership! Learn more on the <a href="{{ 'membership' | absolute_url }}">membership page</a>.
       </p>
     {%- endif -%}
 
     <div class='home-banner'>
       <div class='home-banner-content'>
         <h2>
-          Double Union is a hacker/maker space for women and nonbinary people in San Francisco.
+          Double Union is a hacker/maker space and community workshop in San Francisco.
         </h2>
         <p>
-          We are a community workshop for working on projects in a comfortable, welcoming environment.
+          We work together to maintain a comfortable, welcoming environment that centers nonbinary people and women who are trans, cis, intersex, queer, straight, and not-fitting-into-those-labels, no matter what you look like. You don't have to prove you belong here.
         </p>
         <div class='home-banner-buttons'>
           <a class='btn btn-primary btn-lg' href='{{ 'membership' | absolute_url }}'>

--- a/index.md
+++ b/index.md
@@ -8,7 +8,9 @@ Things people do in this space include sewing, programming, electronics, screenp
 
 Fast internet, shared tools, a carefully curated library of books and zines, and discussion spaces make this a great space for working on your projects, learning skills, and meeting new friends.
 
-Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. We center nonbinary people and women who are trans, cis, intersex, queer, straight, and not-fitting-into-those-labels. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see [membership qualifications]({{ 'membership/#membership-qualifications' | absolute_url }}).
+Double Union is a supportive community for feminist activism. We strive to be intersectional feminists. Membership is open to all nonbinary people and all women, self-identified. For details about what we mean, see [membership qualifications]({{ 'membership/#membership-qualifications' | absolute_url }}).
+
+Members pay dues on a sliding-scale basis between $0-100 per month, typically $25 or $50, for unlimited access. We are volunteer-run, and members can participate in maintainence, event-organizing, and leadership.
 
 ### Visiting Double Union: Classes and Events
 
@@ -31,8 +33,6 @@ Double Union is accepting new members! Members join through an application and v
 {% else %}
 Members join through an application and voting process. If you're interested in being part of Double Union, please subscribe to our social media (listed above) to receive an announcement when we reopen membership applications.
 {% endif %}
-
-Members pay dues on a sliding-scale basis between $0-100 per month, typically $25 or $50.
 
 Check out our [membership page]({{ 'membership' | absolute_url }}) to learn more.
 


### PR DESCRIPTION
This change:

* Adds "community workshop" to the headline, equal to the concept of "hacker/maker space".
* Moves up our open-ended description of who is eligible for membership.
* Removes the application deadline on the homepage, since we're aiming to have ongoing applications instead of a defined period.
* Emphasizes our low dues
* States that we are volunteer-run