### PR TITLE
More info for donor-advised funds

### DIFF
--- a/_includes/donate.html
+++ b/_includes/donate.html
@@ -17,3 +17,5 @@
   2443 Fillmore St #380-8811<br/>
   San Francisco, CA 94115
 </p>
+
+<p>You may also need to provide our email address: board@doubleunion.org. If you need other information for your grant, such as a contact person's name and phone number, email us and we'll provide that for you.</p>


### PR DESCRIPTION
Some donor-advised funds need more contact info for the org, so I added some notes to the supporting page to help people who want to do that.